### PR TITLE
Doc fixes

### DIFF
--- a/lib/analyze.mli
+++ b/lib/analyze.mli
@@ -27,9 +27,9 @@
     Using {!OLS} with the above data would yield an estimated execution time of
     [9.6] nanoseconds with a goodness of fit ([r²]) of [0.992].
 
-    More generally, Bechamel lets the user to choose {i predictors} and the
+    More generally, Bechamel lets the user choose the {i predictors} and
     {i responder}. Indeed, the user can use others metrics (such as [perf]) and
-    the API allows to analyze such metrics each other. *)
+    the API allows to analyze such metrics together. *)
 
 module OLS : sig
   type t

--- a/lib/analyze.mli
+++ b/lib/analyze.mli
@@ -70,19 +70,19 @@ module RANSAC : sig
 end
 
 type 'a t
-(** Type of analyze. *)
+(** Type of analysis. *)
 
 val ols : r_square:bool -> bootstrap:int -> predictors:string array -> OLS.t t
-(** [ols ~r_square ~bootstrap ~predictors] is an Ordinary Least Square analyze
+(** [ols ~r_square ~bootstrap ~predictors] is an Ordinary Least Square analysis
     on [predictors]. It calculate [r²] if [r_square = true]. [bootstrap] is the
     number of how many times Bechamel try to {i resample} measurements. *)
 
 val ransac : filter_outliers:bool -> predictor:string -> RANSAC.t t
 
 val one : 'a t -> Measure.witness -> Benchmark.t -> 'a
-(** [one analyze measure { Benchmark.stat; lr; kde; }] estimates the actual
+(** [one analysis measure { Benchmark.stat; lr; kde; }] estimates the actual
     given [measure] for one [predictors]. So,
-    [one analyze time { Benchmark.stat; lr; kde; }] where [analyze] is
+    [one analysis time { Benchmark.stat; lr; kde; }] where [analysis] is
     initialized with [run] {i predictor} wants to estimate actual
     {i run}-[time] (or execution time) value. *)
 
@@ -91,7 +91,7 @@ val all :
   -> Measure.witness
   -> (string, Benchmark.t) Hashtbl.t
   -> (string, 'a) Hashtbl.t
-(** [all analyze measure tbl] is an application of {!val:one} for all results
+(** [all analysis measure tbl] is an application of {!val:one} for all results
     from the given [tbl]. *)
 
 val merge :

--- a/lib/analyze.mli
+++ b/lib/analyze.mli
@@ -74,17 +74,17 @@ type 'a t
 
 val ols : r_square:bool -> bootstrap:int -> predictors:string array -> OLS.t t
 (** [ols ~r_square ~bootstrap ~predictors] is an Ordinary Least Square analysis
-    on [predictors]. It calculate [r²] if [r_square = true]. [bootstrap] is the
-    number of how many times Bechamel try to {i resample} measurements. *)
+    on [predictors]. It calculates [r²] if [r_square = true]. [bootstrap] defines
+     how many times Bechamel tries to {i resample} measurements. *)
 
 val ransac : filter_outliers:bool -> predictor:string -> RANSAC.t t
 
 val one : 'a t -> Measure.witness -> Benchmark.t -> 'a
 (** [one analysis measure { Benchmark.stat; lr; kde; }] estimates the actual
-    given [measure] for one [predictors]. So,
-    [one analysis time { Benchmark.stat; lr; kde; }] where [analysis] is
-    initialized with [run] {i predictor} wants to estimate actual
-    {i run}-[time] (or execution time) value. *)
+    given [measure] for one [predictor]. So,
+    [one analysis time { Benchmark.stat; lr; kde; }]
+     wants to estimate actual {i run}-[time] (or execution time) value,
+     where [analysis] is initialized with [run] {i predictor}. *)
 
 val all :
      'a t

--- a/lib/bechamel.mli
+++ b/lib/bechamel.mli
@@ -173,7 +173,7 @@
     Bechamel has many ways to show results, but the core still is agnostic
     to the system and does not need anything (like {!module:Unix}) to show
     results. However, the distribution comes with many possibilities:
-    - A [notty] which show you results into your terminal
+    - A [notty] which shows your results in a terminal
     - An HTML + JavaScript which produces an [index.html]
 
     We will try to show the results {i via} our terminal, but the HTML +

--- a/lib/bechamel.mli
+++ b/lib/bechamel.mli
@@ -15,7 +15,7 @@
 
     Bechamel should {b not} lead to premature optimization. It gives only
     clues/metrics about what you use, but you {b must} recontextualize results
-    according to your case to lead to {i certain} optimization.
+    according to your case to lead to {i certain} optimizations.
 
     {2 How to use Bechamel?}
 
@@ -95,7 +95,7 @@
         Benchmark.all cfg instances tests
     ]}
 
-    The benchmark has many options and you should take a look on
+    The benchmark has many options and you should take a look at
     {!val:Benchmark.cfg}. They permit to refine the context of the execution.
     For instance, you can {i stabilize} the garbage-collector.
 
@@ -105,7 +105,7 @@
     {3 Analyze results.}
 
     Finally, you probably want to know the time spent by our factorial
-    functions! This result requires an analyze from metrics. Indeed, if you run
+    functions! This result requires to analyze our metrics. Indeed, if you run
     one time [fact0] and record the monotonic clock, you will
     probably get a {i partial} result which fluctuated a lot per run:
     {[
@@ -128,7 +128,7 @@
     ]}
 
     This is why Bechamel exists. From metrics, it can estimate the time spent
-    by our test. It exists 2 methods to do that:
+    by our test. There are 2 methods to do that:
     - calculate the Ordinary Least Square from metrics
     - calculate the RANdom Sample Consensus from metrics
 

--- a/lib/bechamel.mli
+++ b/lib/bechamel.mli
@@ -1,14 +1,14 @@
 (** {1 Bechamel, a simple and agnostic micro-benchmarking framework.}
 
     Bechamel is a simple and {i agnostic} micro-benchmarking framework to help
-    the developer to prove some metrics and compare them for a {b small} given
-    function. It's measuring the performance of something "small", like a
+    the developer prove and compare metrics for a given {b small} function.
+    It's measuring the performance of something "small", like a
     system call. Bechamel does not do, as we say, a macro-benchmark which can
-    show performance regression or I/O congestion for instance. It permits just
-    to assert that a simple call of a small function [fn1] can be faster
-    (if you use a {i time} metric) than a call of another small function
-    [fn2].
+    show a performance regression or I/O congestion for instance.
 
+    It just permits to assert that a simple call of a small function [fn1]
+    can be faster than a call of another small function [fn2]
+    (if you use a {i time} metric).
     In this way, it asserts that [fn1] should be more efficient than [fn2] and
     it lets the developer {b deduce} the best choice according to the
     runtime context.

--- a/lib/bechamel.mli
+++ b/lib/bechamel.mli
@@ -68,7 +68,7 @@
       {i benchmark} and released after. For instance, we can allocate a
       {i socket}, run {!val:Unix.write} and record metrics and release
       ({!val:Unix.close}) the resource then.
-    - Finally, we can define an {i indexed} with a required resource test
+    - Finally, we can define an {i indexed} test with a required resource
 
     {3 Run the benchmark.}
 

--- a/lib/bechamel.mli
+++ b/lib/bechamel.mli
@@ -158,9 +158,9 @@
   +-----+------+------------+
     v}
 
-    From these metrics, we can guess a curve: [a * x + b = y] where, from our
+    From these metrics, we can fit a curve: [a * x + b = y] where, from our
     code, [x = Measure.run] and [y = Instance.monotonic_clock]. OLS and
-    RANSAC are algorithms which try to guess this curve. Then, [a] will becomes
+    RANSAC are algorithms which try to fit this curve. Then, [a] will become
     the time spent by our function for [x = 1] and this is what we want:
 
     > How much time do I spend if I call my function {b one time}?

--- a/lib/benchmark.mli
+++ b/lib/benchmark.mli
@@ -24,7 +24,7 @@ val cfg :
       benchmarks is actually 2x[quota].
     - [sampling] is the way to grow the [run] metric (default to
       [`Geometric 1.0.1]).
-    - [stabilize] allows the benchamrk to {i stabilize} the garbage collector
+    - [stabilize] allows the benchmark to {i stabilize} the garbage collector
       before each run (default to [true]).
     - [start] is the first value of the [run] metric (default to [1]). *)
 
@@ -57,7 +57,7 @@ type t =
     - [stats] contains all the information about the benchmarks as described
       above
     - [lr] contains the measurements necessary for oLS and ransac analysis.
-    - [kde] optionnaly contains more measurements to enable the display of
+    - [kde] optionally contains more measurements to enable the display of
       density function (KDE or histogram) with the js display. *)
 
 val run : configuration -> Measure.witness list -> Test.Elt.t -> t

--- a/lib/measure.mli
+++ b/lib/measure.mli
@@ -20,7 +20,7 @@ val load : witness -> unit
     record the underlying measure. *)
 
 val unload : witness -> unit
-(** [unload w] releases operating-system's resources to record the underlying
+(** [unload w] releases the operating-system's resources used record the underlying
     measure. *)
 
 val label : witness -> string

--- a/lib/measure.mli
+++ b/lib/measure.mli
@@ -5,7 +5,7 @@ type 'a measure
 (** Type of measure. ['a] represents the {i witness} to record the measure. *)
 
 type witness
-(** Abtract type of a {i witness} to be able to record a {!measure}. *)
+(** Abstract type of a {i witness} to be able to record a {!measure}. *)
 
 val register : 'w impl -> 'w measure
 (** [register (module Measure)] registers a implementation to record a specific
@@ -16,11 +16,11 @@ val instance : 'w impl -> 'w measure -> witness
     introspect a measure [measure]. *)
 
 val load : witness -> unit
-(** [load w] signals to the operating-system to allocate ressources needed to
+(** [load w] signals to the operating-system to allocate resources needed to
     record the underlying measure. *)
 
 val unload : witness -> unit
-(** [unload w] releases operating-system's ressources to record the underlying
+(** [unload w] releases operating-system's resources to record the underlying
     measure. *)
 
 val label : witness -> string

--- a/lib/test.mli
+++ b/lib/test.mli
@@ -129,7 +129,7 @@ val make_grouped : name:string -> ?fmt:fmt_grouped -> t list -> t
       let test = Test.make_grouped ~name:"fibonacci" [ f0; f1; ] ;;
     ]}
 
-    This kind of test is helpful to compare results betwen many implementations. *)
+    This kind of test is helpful to compare results between many implementations. *)
 
 val name : t -> string
 (** [name t] returns the name of the test. *)


### PR DESCRIPTION
I've noticed some typos and fixed them.
I've also found some paragraphs/docstrings in Bechamel.mli a bit difficult to follow, having to reread some sentences and "parse" them more carefully to understand their meaning. The master branch is already better than 0.2.0 in this regard, but I think the sentences can be made easier to read by rearranging their order or simplifying them in some cases.

One docstring that was difficult to read was this:
```
So,
    [one analyze time { Benchmark.stat; lr; kde; }] where [analyze] is
    initialized with [run] {i predictor} wants to estimate actual
    {i run}-[time] (or execution time) value
```

I think some commas or other separators would've helped clarify what the subject of 'wants' is, but I think this is easier to understand if written like this where we get to the point sooner and define all the pieces at the end.
Also using a noun fits better:
```
    So,
   [one analysis time { Benchmark.stat; lr; kde; }]
     wants to estimate actual {i run}-[time] (or execution time) value,
     where [analysis] is initialized with [run] {i predictor}.
```

I'm not a native speaker, so the changes here may not be entirely correct, or optimal. I tried to separate each change into its own commit with a small justification of why I think the change improves the documentation.
It'd be ideal if a native speaker could review these changes.