### PR TITLE
windows: use caml_copy_int64 so that it links on ocaml 5.0.0+

### DIFF
--- a/.github/workflows/wintest.yml
+++ b/.github/workflows/wintest.yml
@@ -1,0 +1,41 @@
+name: CI
+
+on: [push, pull_request]
+
+jobs:
+  winbuild:
+    runs-on: windows-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Set-up OCaml
+        uses: ocaml/setup-ocaml@v2
+        with:
+          ocaml-compiler: ocaml.5.0.0,ocaml-option-mingw
+          opam-local-packages: bechamel.opam
+          opam-repositories: |
+            dra27: https://github.com/dra27/opam-repository.git#windows-5.0
+            default: https://github.com/fdopen/opam-repository-mingw.git#opam2
+
+      - run: opam pin add . -n
+      - run: opam install bechamel --with-test -v
+
+  winbuild4:
+    runs-on: windows-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Set-up OCaml
+        uses: ocaml/setup-ocaml@v2
+        with:
+          ocaml-compiler: 4.14.0
+          opam-local-packages: bechamel.opam
+          opam-repositories: |
+            default: https://github.com/fdopen/opam-repository-mingw.git#opam2
+
+      - run: opam pin add . -n
+      - run: opam install bechamel --with-test -v

--- a/lib/monotonic_clock/clock_windows_stubs.c
+++ b/lib/monotonic_clock/clock_windows_stubs.c
@@ -44,7 +44,7 @@ clock_windows_get_time(value unit)
 
   QueryPerformanceCounter(&now);
 
-  res = copy_int64(now.QuadPart * frequency.QuadPart);
+  res = caml_copy_int64(now.QuadPart * frequency.QuadPart);
 
   CAMLreturn(res);
 }

--- a/lib/monotonic_clock/select/select.ml
+++ b/lib/monotonic_clock/select/select.ml
@@ -1,11 +1,14 @@
 let invalid_arg fmt = Format.ksprintf (fun s -> invalid_arg s) fmt
 
 let load_file filename =
-  let ic = open_in filename in
-  let ln = in_channel_length ic in
-  let rs = Bytes.create ln in
-  let () = really_input ic rs 0 ln in
-  Bytes.unsafe_to_string rs
+  try
+    let ic = open_in filename in
+    let ln = in_channel_length ic in
+    let rs = Bytes.create ln in
+    let () = really_input ic rs 0 ln in
+    Bytes.unsafe_to_string rs
+  with
+    End_of_file -> invalid_arg ("EOF reading " ^ filename)
 
 let sexp_linux = "(-lrt)"
 let sexp_empty = "()"

--- a/lib/monotonic_clock/select/select.ml
+++ b/lib/monotonic_clock/select/select.ml
@@ -2,13 +2,12 @@ let invalid_arg fmt = Format.ksprintf (fun s -> invalid_arg s) fmt
 
 let load_file filename =
   try
-    let ic = open_in filename in
+    let ic = open_in_bin filename in
     let ln = in_channel_length ic in
     let rs = Bytes.create ln in
     let () = really_input ic rs 0 ln in
     Bytes.unsafe_to_string rs
-  with
-    End_of_file -> invalid_arg ("EOF reading " ^ filename)
+  with End_of_file -> invalid_arg "EOF reading: %S" filename
 
 let sexp_linux = "(-lrt)"
 let sexp_empty = "()"


### PR DESCRIPTION
This fixes the link with bechamel on OCaml 5 (which removes the deprecated symbol) and Windows.