### PR TITLE
Bechamel: fix unsafe off by one causing SIGSEGV on OCaml 5.0

### DIFF
--- a/lib/benchmark.ml
+++ b/lib/benchmark.ml
@@ -86,10 +86,11 @@ let run cfg measures test : t =
   let (allocate0 : unit -> _), free0, (allocate1 : int -> _), free1 =
     match kind with
     | Test.Uniq ->
+        let v = [| Test.Uniq.prj (allocate ()) |] in
         ( (fun () -> Test.Uniq.prj (allocate ()))
         , (fun v -> free (Test.Uniq.inj v))
-        , always empty_array
-        , ignore )
+        , always v
+        , fun a -> a |> Array.iter @@ fun v -> free (Test.Uniq.inj v) )
     | Test.Multiple ->
         let v = unsafe_get (Test.Multiple.prj (allocate 1)) 0 in
         ( always v

--- a/lib/benchmark.ml
+++ b/lib/benchmark.ml
@@ -91,7 +91,7 @@ let run cfg measures test : t =
         , always empty_array
         , ignore )
     | Test.Multiple ->
-        let v = unsafe_get (Test.Multiple.prj (allocate 1)) 1 in
+        let v = unsafe_get (Test.Multiple.prj (allocate 1)) 0 in
         ( always v
         , (fun v -> free (Test.Multiple.inj [| v |]))
         , (fun n -> Test.Multiple.prj (allocate n))

--- a/lib/benchmark.ml
+++ b/lib/benchmark.ml
@@ -1,11 +1,10 @@
-external unsafe_get : 'a array -> int -> 'a = "%array_unsafe_get"
+open Unsafe
 
 let always x _ = x
-let empty_array = [||]
 
 let runnable_with_resources f vs i =
   for _ = 1 to i do
-    ignore (Sys.opaque_identity (f (unsafe_get vs (i - 1))))
+    ignore (Sys.opaque_identity (f (unsafe_array_get vs (i - 1))))
   done
   [@@inline]
 
@@ -92,7 +91,7 @@ let run cfg measures test : t =
         , always v
         , fun a -> a |> Array.iter @@ fun v -> free (Test.Uniq.inj v) )
     | Test.Multiple ->
-        let v = unsafe_get (Test.Multiple.prj (allocate 1)) 0 in
+        let v = unsafe_array_get (Test.Multiple.prj (allocate 1)) 0 in
         ( always v
         , (fun v -> free (Test.Multiple.inj [| v |]))
         , (fun n -> Test.Multiple.prj (allocate n))
@@ -185,7 +184,7 @@ let run cfg measures test : t =
           && !current_idx < kde_limit
         do
           let resources = allocate1 1 in
-          let resource = unsafe_get resources 0 in
+          let resource = unsafe_array_get resources 0 in
 
           for i = 0 to length - 1 do
             m0.(i) <- records.(i) ()

--- a/lib/staged.ml
+++ b/lib/staged.ml
@@ -1,4 +1,4 @@
 type 'a t = 'a
 
-external stage : 'a -> 'a t = "%identity"
-external unstage : 'a t -> 'a = "%identity"
+let stage = Sys.opaque_identity
+let unstage = Sys.opaque_identity

--- a/lib/test.ml
+++ b/lib/test.ml
@@ -89,9 +89,7 @@ let make ~name fn =
       ]
   }
 
-external unsafe_array_make : int -> 'a -> 'a array = "caml_make_vect"
-external unsafe_array_get : 'a array -> int -> 'a = "%array_unsafe_get"
-external unsafe_array_set : 'a array -> int -> 'a -> unit = "%array_unsafe_set"
+open Unsafe
 
 let make_multiple_allocate f = function
   | 0 -> [||]

--- a/lib/unsafe.ml
+++ b/lib/unsafe.ml
@@ -1,0 +1,3 @@
+let unsafe_array_make = Array.make
+let unsafe_array_get = Array.unsafe_get
+let unsafe_array_set = Array.unsafe_set


### PR DESCRIPTION
My benchmark was running fine on OCaml 4.x but always segfaulting on OCaml 5.0.
Took a while to track down the root cause, was trying to eliminate all unsafe code one by one until I found the problem: replacing the `unsafe_array_get` with Array.get raised an out of bounds error, which immediately highlighted the off by one error.

(I think some of the unsafe code usage could actually be replaced with something safer without sacrificing performance, I'll open another PR if I have something useful).

This change makes my benchmarks able to run on OCaml 5 again!