### PR TITLE
Update system detection for monotonic clock

### DIFF
--- a/lib/monotonic_clock/select/select.ml
+++ b/lib/monotonic_clock/select/select.ml
@@ -22,6 +22,9 @@ let () =
           | "win32" | "win64" | "mingw64" | "mingw" | "cygwin" -> `Windows
           | "freebsd" -> `FreeBSD
           | "macosx" -> `MacOSX
+          | "beos" | "dragonfly" | "bsd" | "openbsd" | "netbsd" | "gnu"
+          | "solaris" | "unknown" ->
+            invalid_arg "Unsupported system: %s" system
           | v ->
             if String.sub system 0 5 = "linux"
             then `Linux

--- a/lib/monotonic_clock/select/select.ml
+++ b/lib/monotonic_clock/select/select.ml
@@ -18,11 +18,14 @@ let () =
     | [| _; "--system"; system; "-o"; output |] ->
         let system =
           match system with
-          | "linux" | "linux_eabihf" | "linux_elf" | "elf" -> `Linux
+          | "linux" | "elf" -> `Linux
           | "win32" | "win64" | "mingw64" | "mingw" | "cygwin" -> `Windows
           | "freebsd" -> `FreeBSD
           | "macosx" -> `MacOSX
-          | v -> invalid_arg "Invalid argument of system option: %s" v
+          | v ->
+            if String.sub system 0 5 = "linux"
+            then `Linux
+            else invalid_arg "Invalid argument of system option: %s" v
         in
         (system, output)
     | _ ->

--- a/lib/monotonic_clock/select/select.ml
+++ b/lib/monotonic_clock/select/select.ml
@@ -19,8 +19,8 @@ let () =
         let system =
           match system with
           | "linux" | "linux_eabihf" | "linux_elf" | "elf" -> `Linux
+          | "win32" | "win64" | "mingw64" | "mingw" | "cygwin" -> `Windows
           | "freebsd" -> `FreeBSD
-          | "windows" | "mingw64" | "cygwin" -> `Windows
           | "macosx" -> `MacOSX
           | v -> invalid_arg "Invalid argument of system option: %s" v
         in

--- a/lib/monotonic_clock/select/select.ml
+++ b/lib/monotonic_clock/select/select.ml
@@ -24,11 +24,10 @@ let () =
           | "macosx" -> `MacOSX
           | "beos" | "dragonfly" | "bsd" | "openbsd" | "netbsd" | "gnu"
           | "solaris" | "unknown" ->
-            invalid_arg "Unsupported system: %s" system
+              invalid_arg "Unsupported system: %s" system
           | v ->
-            if String.sub system 0 5 = "linux"
-            then `Linux
-            else invalid_arg "Invalid argument of system option: %s" v
+              if String.sub system 0 5 = "linux" then `Linux
+              else invalid_arg "Invalid argument of system option: %s" v
         in
         (system, output)
     | _ ->


### PR DESCRIPTION
cf. mirage/eqaf#40.

- Add missing case for 32-bit mingw-w64 (in eqaf already)
- Simplify the detection of linux (in eqaf already) - also catches `linux_eabi`
- Use the correct values for the MSVC ports of OCaml (not tested; spotted that they're wrong as part of ocaml/ocaml#12405)
- Explicitly list the "known" OCaml system values