### PR TITLE
Bechamel_perf: fix running as non-root user

### DIFF
--- a/.github/workflows/wintest.yml
+++ b/.github/workflows/wintest.yml
@@ -8,7 +8,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set-up OCaml
         uses: ocaml/setup-ocaml@v2
@@ -28,7 +28,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set-up OCaml
         uses: ocaml/setup-ocaml@v2

--- a/bechamel-js.opam
+++ b/bechamel-js.opam
@@ -24,4 +24,5 @@ depends: [
   "json-data-encoding"
   "jsonm"
   "fmt"        {>= "0.9.0"}
+  "result"
 ]

--- a/examples/dune
+++ b/examples/dune
@@ -3,7 +3,7 @@
  (modules list)
  (public_name bechamel-notty.examples.list)
  (package bechamel-notty)
- (libraries bechamel notty.unix bechamel-notty))
+ (libraries bechamel notty.unix unix bechamel-notty))
 
 (executable
  (name sqrt)

--- a/lib/perf/bechamel_perf.ml
+++ b/lib/perf/bechamel_perf.ml
@@ -8,7 +8,12 @@ struct
 
   let load witness = Perf.enable witness
   let unload witness = Perf.disable witness
-  let make () = Perf.make (Perf.Attr.make X.kind)
+
+  let make () =
+    try Perf.make (Perf.Attr.make X.kind)
+    with Unix.Unix_error (Unix.EACCES, _, _) ->
+      (* kernel.perf_event_paranoid doesn't allow measuring the kernel *)
+      Perf.make (Perf.Attr.make ~flags:[ Perf.Attr.Exclude_kernel ] X.kind)
 
   let label witness =
     let kind = Perf.kind witness in

--- a/lib/perf/bechamel_perf.mli
+++ b/lib/perf/bechamel_perf.mli
@@ -9,7 +9,9 @@
     If you want to use [Bechamel_perf] as a normal user, you should take a look
     on {{:https://www.kernel.org/doc/Documentation/sysctl/kernel.txt}the
     documentation about [perf_paranoid]}.
-*)
+
+    If the user wants to measuring the kernel, the program must be run as root.
+    We cannot measure in a virtualized environment ([ENOENT] is returned). *)
 
 open Bechamel
 

--- a/lib/perf/dune
+++ b/lib/perf/dune
@@ -1,4 +1,4 @@
 (library
  (name bechamel_perf)
  (public_name bechamel-perf)
- (libraries mperf bechamel))
+ (libraries mperf bechamel unix))

--- a/mperf.opam
+++ b/mperf.opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
 name:         "mperf"
-version:      "0.1"
+version:      "0.5"
 maintainer:   [ "Romain Calascibetta <romain.calascibetta@gmail.com>" ]
 authors:      [ "Vincent Bernardoff <vincent.bernardoff@ocamlpro.com>" "Pierre Chambart <pierre.chambart@ocamlpro.com>" ]
 homepage:     "http://github.com/dinosaure/bechamel"

--- a/mperf/lib/mperf_stubs.c
+++ b/mperf/lib/mperf_stubs.c
@@ -11,6 +11,7 @@
 #include <caml/mlvalues.h>
 #include <caml/fail.h>
 #include <caml/memory.h>
+#include <caml/unixsupport.h>
 
 static long
 perf_event_open(struct perf_event_attr *hw_event, pid_t pid,
@@ -29,7 +30,7 @@ CAMLprim value mperf_events_enable_all (value unit)
   ret = prctl(PR_TASK_PERF_EVENTS_ENABLE, 0, 0, 0, 0);
 
   if(ret == -1)
-    caml_failwith(strerror(errno));
+    uerror(__func__, Nothing);
 
   CAMLreturn(Val_unit);
 }
@@ -41,7 +42,7 @@ CAMLprim value mperf_events_disable_all (value unit)
   ret = prctl(PR_TASK_PERF_EVENTS_DISABLE, 0, 0, 0, 0);
 
   if(ret == -1)
-    caml_failwith(strerror(errno));
+    uerror(__func__, Nothing);
 
   CAMLreturn(Val_unit);
 }
@@ -53,7 +54,7 @@ CAMLprim value mperf_event_ioc_enable (value fd)
   ret = ioctl(Int_val(fd), PERF_EVENT_IOC_ENABLE);
 
   if(ret == -1)
-    caml_failwith(strerror(errno));
+    uerror(__func__, Nothing);
 
   CAMLreturn(Val_unit);
 }
@@ -65,7 +66,7 @@ CAMLprim value mperf_event_ioc_disable (value fd)
   ret = ioctl(Int_val(fd), PERF_EVENT_IOC_DISABLE);
 
   if(ret == -1)
-    caml_failwith(strerror(errno));
+    uerror(__func__, Nothing);
 
   CAMLreturn(Val_unit);
 }
@@ -77,7 +78,7 @@ CAMLprim value mperf_event_ioc_reset (value fd)
   ret = ioctl(Int_val(fd), PERF_EVENT_IOC_RESET);
 
   if(ret == -1)
-    caml_failwith(strerror(errno));
+    uerror(__func__, Nothing);
 
   CAMLreturn(Val_unit);
 }
@@ -139,7 +140,7 @@ CAMLprim value mperf_event_open_native (value kind, value attr_flags,
   ret = perf_event_open(&attr, Int_val(pid), Int_val(cpu), Int_val(group_fd), c_flags);
 
   if(ret == -1)
-    caml_failwith(strerror(errno));
+    uerror(__func__, Nothing);
 
   CAMLreturn(Val_int(ret));
 }


### PR DESCRIPTION
By default my system (Fedora 40) has `kernel.perf_event_paranoid` set to 2, which doesn't allow non-root users to measure the kernel. 

This causes `Bechamel_perf` to fail to load when linked into a program (even if I don't actually use any of its metrics), because the perf event is opened at module startup time, and not at Measure `load` time.

Catch the permission error and fall back to not measuring the kernel.