### PR TITLE
Minor_allocated: Use Gc.minor_words

### DIFF
--- a/lib/toolkit.ml
+++ b/lib/toolkit.ml
@@ -15,7 +15,7 @@ module Minor_allocated = struct
   let load () = ()
   let unload () = ()
   let make () = ()
-  let get () = (Gc.quick_stat ()).minor_words
+  let get () = Gc.minor_words ()
   let label () = "minor-allocated"
   let unit () = "mnw"
 end


### PR DESCRIPTION
`Minor_allocated` was showing a result of `0.0000 mnw/run`, possibly because my benchmarks weren't triggering minor collections.

With this change, the results seems more accurate but the R² is low (printed on a red background in the notty output).
The R² seems unchanged for tests that trigger minor collections.

What do you think ?