### PR TITLE
Simpler API for table outputs

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,2 +1,3 @@
 # Apply ocamlformat.0.29.0
 b00ef112a1b296d5db08f427b1d1dd567245c965
+a7922cf1b5cb2569ef367dd1a774caf75e541a04

--- a/bechamel.opam
+++ b/bechamel.opam
@@ -18,7 +18,7 @@ build: [
 ]
 
 depends: [
-  "ocaml"      {>= "4.08.0"}
+  "ocaml"      {>= "4.10.0"}
   "dune"       {>= "2.0.0"}
   "fmt"        {>= "0.9.0"}
   "alcotest"   {with-test}

--- a/lib/analyze.ml
+++ b/lib/analyze.ml
@@ -358,41 +358,32 @@ let merge : type a.
   ret
 
 let ols_to_table ~instances ~bootstrap ~r_square ~predictors results =
-  let ols = Analyze.ols ~bootstrap ~r_square ~predictors in
+  let ols = ols ~bootstrap ~r_square ~predictors in
   let metrics =
     List.init (Array.length predictors) (fun i -> `Predictor i)
     @ if r_square then [ `R_square ] else []
   in
   let rows =
-    List.map
-      (fun (test_name, results) ->
-        ( test_name
-        , List.concat_map
-            (fun inst ->
-              let ols = Analyze.one ols inst results in
-              let estimates =
-                Option.value ~default:[] (Analyze.OLS.estimates ols)
-              in
-              List.map
-                (function
-                  | `Predictor i ->
-                      Option.value ~default:Float.nan (List.nth_opt estimates i)
-                  | `R_square ->
-                      Option.value ~default:Float.nan (Analyze.OLS.r_square ols))
-                metrics)
-            instances ))
-      results
-  in
+    let fn (test_name, results)=
+      let per_insts =
+        let fn inst =
+          let ols = one ols inst results in
+          let estimates = Option.value ~default:[] (OLS.estimates ols) in
+          let fn = function
+             | `Predictor idx -> Option.value ~default:Float.nan (List.nth_opt estimates idx)
+             | `R_square -> Option.value ~default:Float.nan (OLS.r_square ols) in
+          List.map fn metrics in
+        List.concat_map fn instances in
+      (test_name, per_insts) in
+    List.map fn results in
   let header =
-    List.concat_map
-      (fun inst ->
-        let lbl = Measure.label inst and unit = Measure.unit inst in
-        List.map
-          (function
-            | `Predictor i ->
-                Printf.sprintf "%s (%s/%s)" lbl unit predictors.(i)
-            | `R_square -> Printf.sprintf "%s (R²)" lbl)
-          metrics)
-      instances
+    let fn inst =
+      let lbl = Measure.label inst
+      and unit = Measure.unit inst in
+      let fn = function
+        | `Predictor idx -> Fmt.str "%s (%s/%s)" lbl unit predictors.(idx)
+        | `R_square -> Fmt.str "%s (R²)" lbl in
+      List.map fn metrics in
+    List.concat_map fn instances
   in
   (header, rows)

--- a/lib/analyze.ml
+++ b/lib/analyze.ml
@@ -356,3 +356,43 @@ let merge : type a.
     (fun instance result -> Hashtbl.add ret (Measure.label instance) result)
     instances results;
   ret
+
+let ols_to_table ~instances ~bootstrap ~r_square ~predictors results =
+  let ols = Analyze.ols ~bootstrap ~r_square ~predictors in
+  let metrics =
+    List.init (Array.length predictors) (fun i -> `Predictor i)
+    @ if r_square then [ `R_square ] else []
+  in
+  let rows =
+    List.map
+      (fun (test_name, results) ->
+        ( test_name
+        , List.concat_map
+            (fun inst ->
+              let ols = Analyze.one ols inst results in
+              let estimates =
+                Option.value ~default:[] (Analyze.OLS.estimates ols)
+              in
+              List.map
+                (function
+                  | `Predictor i ->
+                      Option.value ~default:Float.nan (List.nth_opt estimates i)
+                  | `R_square ->
+                      Option.value ~default:Float.nan (Analyze.OLS.r_square ols))
+                metrics)
+            instances ))
+      results
+  in
+  let header =
+    List.concat_map
+      (fun inst ->
+        let lbl = Measure.label inst and unit = Measure.unit inst in
+        List.map
+          (function
+            | `Predictor i ->
+                Printf.sprintf "%s (%s/%s)" lbl unit predictors.(i)
+            | `R_square -> Printf.sprintf "%s (R²)" lbl)
+          metrics)
+      instances
+  in
+  (header, rows)

--- a/lib/analyze.ml
+++ b/lib/analyze.ml
@@ -364,26 +364,33 @@ let ols_to_table ~instances ~bootstrap ~r_square ~predictors results =
     @ if r_square then [ `R_square ] else []
   in
   let rows =
-    let fn (test_name, results)=
+    let fn (test_name, results) =
       let per_insts =
         let fn inst =
           let ols = one ols inst results in
           let estimates = Option.value ~default:[] (OLS.estimates ols) in
           let fn = function
-             | `Predictor idx -> Option.value ~default:Float.nan (List.nth_opt estimates idx)
-             | `R_square -> Option.value ~default:Float.nan (OLS.r_square ols) in
-          List.map fn metrics in
-        List.concat_map fn instances in
-      (test_name, per_insts) in
-    List.map fn results in
+            | `Predictor idx ->
+                Option.value ~default:Float.nan (List.nth_opt estimates idx)
+            | `R_square -> Option.value ~default:Float.nan (OLS.r_square ols)
+          in
+          List.map fn metrics
+        in
+        List.concat_map fn instances
+      in
+      (test_name, per_insts)
+    in
+    List.map fn results
+  in
   let header =
     let fn inst =
-      let lbl = Measure.label inst
-      and unit = Measure.unit inst in
+      let lbl = Measure.label inst and unit = Measure.unit inst in
       let fn = function
         | `Predictor idx -> Fmt.str "%s (%s/%s)" lbl unit predictors.(idx)
-        | `R_square -> Fmt.str "%s (R²)" lbl in
-      List.map fn metrics in
+        | `R_square -> Fmt.str "%s (R²)" lbl
+      in
+      List.map fn metrics
+    in
     List.concat_map fn instances
   in
   (header, rows)

--- a/lib/analyze.mli
+++ b/lib/analyze.mli
@@ -102,3 +102,40 @@ val merge :
 (** [merge witnesses tbls] returns a dictionary where the key is the {i label}
     of a measure (from the given [witnesses]) and the value is the result of
     this specific measure. *)
+
+val ols_to_table :
+     r_square:bool
+  -> bootstrap:int
+  -> predictors:string array
+  -> (string * Benchmark.t) list
+  -> string list * (string * float list) list
+(** Analyze the test results using OLS and return the result in a tablular
+    format. Example usage:
+
+    {@ocaml[
+      let tests = [ (* Test.make ... *) ]
+      let instances = Instance.[ monotonic_clock; minor_allocated; promoted ]
+      let predictors = [| Measure.run |]
+
+      let benchmark () =
+        let cfg = Benchmark.cfg ~quota:(Time.second 0.33) () in
+        List.map
+          (fun t -> (Test.Elt.name t, Benchmark.run cfg instances t))
+          (Test.expand tests)
+
+      let output_csv (header, rows) =
+        let rows =
+          List.map
+            (fun (test_name, data) ->
+              test_name :: List.map string_of_float data)
+            rows
+        in
+        let outf = "results.csv" in
+        Csv.save outf (("Test name" :: header) :: rows);
+        Printf.eprintf "Output saved to %S.\n%!" outf
+
+      let () =
+        benchmark ()
+        |> analyze_to_table ~instances ~bootstrap:0 ~r_square:false ~predictors
+        |> output_csv
+    ]} *)

--- a/lib/analyze.mli
+++ b/lib/analyze.mli
@@ -104,8 +104,9 @@ val merge :
     this specific measure. *)
 
 val ols_to_table :
-     r_square:bool
+     instances:Measure.witness list
   -> bootstrap:int
+  -> r_square:bool
   -> predictors:string array
   -> (string * Benchmark.t) list
   -> string list * (string * float list) list

--- a/lib/analyze.mli
+++ b/lib/analyze.mli
@@ -114,29 +114,28 @@ val ols_to_table :
     format. Example usage:
 
     {@ocaml[
-      let tests = [ (* Test.make ... *) ]
-      let instances = Instance.[ monotonic_clock; minor_allocated; promoted ]
-      let predictors = [| Measure.run |]
+    let tests = [ (* Test.make ... *) ]
+    let instances = Instance.[ monotonic_clock; minor_allocated; promoted ]
+    let predictors = [| Measure.run |]
 
-      let benchmark () =
-        let cfg = Benchmark.cfg ~quota:(Time.second 0.33) () in
+    let benchmark () =
+      let cfg = Benchmark.cfg ~quota:(Time.second 0.33) () in
+      List.map
+        (fun t -> (Test.Elt.name t, Benchmark.run cfg instances t))
+        (Test.expand tests)
+
+    let output_csv (header, rows) =
+      let rows =
         List.map
-          (fun t -> (Test.Elt.name t, Benchmark.run cfg instances t))
-          (Test.expand tests)
+          (fun (test_name, data) -> test_name :: List.map string_of_float data)
+          rows
+      in
+      let outf = "results.csv" in
+      Csv.save outf (("Test name" :: header) :: rows);
+      Printf.eprintf "Output saved to %S.\n%!" outf
 
-      let output_csv (header, rows) =
-        let rows =
-          List.map
-            (fun (test_name, data) ->
-              test_name :: List.map string_of_float data)
-            rows
-        in
-        let outf = "results.csv" in
-        Csv.save outf (("Test name" :: header) :: rows);
-        Printf.eprintf "Output saved to %S.\n%!" outf
-
-      let () =
-        benchmark ()
-        |> analyze_to_table ~instances ~bootstrap:0 ~r_square:false ~predictors
-        |> output_csv
+    let () =
+      benchmark ()
+      |> analyze_to_table ~instances ~bootstrap:0 ~r_square:false ~predictors
+      |> output_csv
     ]} *)


### PR DESCRIPTION
I wanted to save the benchmark results into a CSV and found that it was quite difficult to deal with the current API.

The code in the examples folder uses the `merge` function, which has a confusing signature. On top of that, it looses the list of test names, which makes creating a CSV output harder and error prone.

I struggled quite a bit to get a correct CSV output, so I figured that it would be worthwhile to support this usecase in the library.

Maybe related to https://github.com/mirage/bechamel/issues/53