### PR TITLE
Use quick_stat with full_major instead of stat (which will be deprecated)

### DIFF
--- a/lib/benchmark.ml
+++ b/lib/benchmark.ml
@@ -31,8 +31,8 @@ let stabilize_garbage_collector () =
   let rec go fail last_heap_live_words =
     if fail <= 0 then
       failwith "Unable to stabilize the number of live words in the major heap";
-    Gc.compact ();
-    let stat = Gc.stat () in
+    Gc.full_major ();
+    let stat = Gc.quick_stat () in
     if stat.Gc.live_words <> last_heap_live_words then
       go (fail - 1) stat.Gc.live_words
   in


### PR DESCRIPTION
See this PR on ocaml/ocaml for more explanation:
https://github.com/ocaml/ocaml/pull/12023

/cc @damiendoligez (to confirm if it's the right usage) and /cc @Julow if it does not disturb your metrics.